### PR TITLE
Vanilla upgrade 2.0.1

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,8 +2,8 @@
     <div class="row">
         <p>&copy; {{ 'now' | date: "%Y" }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
         <ul class="p-inline-list--middot">
-            <li class="p-inline-list__item"><a class="p-link" aria-label="External link to the Ubuntu legal information page" href="http://www.ubuntu.com/legal">Legal information</a></li>
-            <li class="p-inline-list__item"><a class="p-link" aria-label="External link to report a bug on this site" href="https://github.com/ubuntudesign/cloud-init/issues/new">Report a bug on this site</a></li>
+            <li class="p-inline-list__item"><a class="p-link--soft" aria-label="External link to the Ubuntu legal information page" href="http://www.ubuntu.com/legal">Legal information</a></li>
+            <li class="p-inline-list__item"><a class="p-link--soft" aria-label="External link to report a bug on this site" href="https://github.com/ubuntudesign/cloud-init/issues/new">Report a bug on this site</a></li>
         </ul>
         <span class="u-off-screen">
             <a href="#">Go to the top of the page</a>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,12 +1,12 @@
 <div class="p-strip is-shallow">
-    <div class="row">
-        <p>&copy; {{ 'now' | date: "%Y" }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
-        <ul class="p-inline-list--middot">
-            <li class="p-inline-list__item"><a class="p-link--soft" aria-label="External link to the Ubuntu legal information page" href="http://www.ubuntu.com/legal">Legal information</a></li>
-            <li class="p-inline-list__item"><a class="p-link--soft" aria-label="External link to report a bug on this site" href="https://github.com/ubuntudesign/cloud-init/issues/new">Report a bug on this site</a></li>
-        </ul>
-        <span class="u-off-screen">
-            <a href="#">Go to the top of the page</a>
-        </span>
-    </div>
+  <div class="row">
+    <p>&copy; {{ 'now' | date: "%Y" }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+    <ul class="p-inline-list--middot">
+      <li class="p-inline-list__item"><a class="p-link--soft" aria-label="External link to the Ubuntu legal information page" href="http://www.ubuntu.com/legal">Legal information</a></li>
+      <li class="p-inline-list__item"><a class="p-link--soft" aria-label="External link to report a bug on this site" href="https://github.com/ubuntudesign/cloud-init/issues/new">Report a bug on this site</a></li>
+    </ul>
+    <span class="u-off-screen">
+      <a href="#">Go to the top of the page</a>
+    </span>
+  </div>
 </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,29 +1,12 @@
-<footer class="p-footer">
-  <div class="row">
-    <div class="col-12">
-      &copy; {{ 'now' | date: "%Y" }} Canonical Ltd. Ubuntu and Canonical are
-      registered trademarks of Canonical Ltd.
-      <nav class="p-footer__nav">
-        <ul class="p-footer__links">
-          <li class="p-footer__item">
-            <a class="p-footer__link"
-              aria-label="External link to the Ubuntu legal information page"
-              href="http://www.ubuntu.com/legal">
-              Legal information
-            </a>
-          </li>
-          <li class="p-footer__item">
-            <a class="p-footer__link"
-              aria-label="External link to report a bug on this site"
-              href="https://github.com/ubuntudesign/cloud-init/issues/new">
-              Report a bug on this site
-            </a>
-          </li>
+<div class="p-strip is-shallow">
+    <div class="row">
+        <p>&copy; {{ 'now' | date: "%Y" }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+        <ul class="p-inline-list--middot">
+            <li class="p-inline-list__item"><a class="p-link" aria-label="External link to the Ubuntu legal information page" href="http://www.ubuntu.com/legal">Legal information</a></li>
+            <li class="p-inline-list__item"><a class="p-link" aria-label="External link to report a bug on this site" href="https://github.com/ubuntudesign/cloud-init/issues/new">Report a bug on this site</a></li>
         </ul>
         <span class="u-off-screen">
-          <a href="#">Go to the top of the page</a>
+            <a href="#">Go to the top of the page</a>
         </span>
-      </nav>
     </div>
-  </div>
-</footer>
+</div>

--- a/index.html
+++ b/index.html
@@ -223,27 +223,68 @@ layout: default
     </div>
   </div>
   <div class="row">
-    <div class="col-6">
+    <div class="col-3">
+      <div class="p-media-object">
+        <img src="https://assets.ubuntu.com/v1/25f16ae4-Joshua-Powers.jpeg" alt="Scott Moser profile picture" class="p-media-object__image is-round">
+        <div class="p-media-object__details">
+          <h3 class="p-media-object__title">Joshua Powers</h3>
+          <p class="p-media-object__content">Josh is the Engineering Manager of Ubuntu Server at Canonical.</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="p-media-object">
+        <img src="https://assets.ubuntu.com/v1/5ddb324e-Ryan-Harper.jpeg" alt="Scott Moser profile picture" class="p-media-object__image is-round">
+        <div class="p-media-object__details">
+          <h3 class="p-media-object__title">Ryan Harper</h3>
+          <p class="p-media-object__content">Ryan is a primary maintainer of cloud-init at Canonical.</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="p-media-object">
+        <img src="https://assets.ubuntu.com/v1/ac3077b5-Chad-Smith.png" alt="Scott Moser profile picture" class="p-media-object__image is-round">
+        <div class="p-media-object__details">
+          <h3 class="p-media-object__title">Chad Smith</h3>
+          <p class="p-media-object__content">Chad is a primary maintainer of cloud-init at Canonical.</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="p-media-object">
+        <img src="https://assets.ubuntu.com/v1/4e6646e1-Dan-Watkins.jpeg" alt="Scott Moser profile picture" class="p-media-object__image is-round">
+        <div class="p-media-object__details">
+          <h3 class="p-media-object__title">Dan Watkins</h3>
+          <p class="p-media-object__content">Dan is a primary maintainer of cloud-init at Canonical.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-3">
+      <div class="p-media-object">
+        <img src="https://assets.ubuntu.com/v1/1833cb79-Paride-Legovini.png" alt="Scott Moser profile picture" class="p-media-object__image is-round">
+        <div class="p-media-object__details">
+          <h3 class="p-media-object__title">Paride Legovini</h3>
+          <p class="p-media-object__content">Paride is the QA engineer on Ubuntu Server at Canonical.</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
       <div class="p-media-object">
         <img src="https://assets.ubuntu.com/v1/64bd8e20-scott-moser.jpg" alt="Scott Moser profile picture" class="p-media-object__image is-round">
         <div class="p-media-object__details">
           <h3 class="p-media-object__title">Scott Moser</h3>
-          <p class="p-media-object__content">
-            <a class="p-link--external" href="https://ubuntu-smoser.blogspot.co.uk/">Scott</a> is the primary author and active maintainer of cloud-init, and is a technical leader on the Ubuntu Server Team for
-            <a class="p-link--external" href="https://www.canonical.com/">Canonical</a>.
-          </p>
+          <p class="p-media-object__content">Scott is the primary author and active maintainer of cloud-init, who works at Cisco.</p>
         </div>
       </div>
     </div>
-    <div class="col-6">
+    <div class="col-3">
       <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/231a0085-joshua-harlow.jpg" alt="Joshua Harlow profile picture" class="p-media-object__image is-round">
+        <img src="https://assets.ubuntu.com/v1/231a0085-joshua-harlow.jpg" alt="Scott Moser profile picture" class="p-media-object__image is-round">
         <div class="p-media-object__details">
           <h3 class="p-media-object__title">Joshua Harlow</h3>
-          <p class="p-media-object__content">
-            <a class="p-link--external" href="https://launchpad.net/~harlowja">Joshua</a> is an active maintainer of cloud-init, hacking on clouds for
-            <a class="p-link--external" href="https://www.godaddy.com/">GoDaddy</a>.
-          </p>
+          <p class="p-media-object__content">Joshua is an active maintainer of cloud-init, who works at PlusAI.</p>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -138,43 +138,37 @@ layout: default
 
 <section class="p-strip">
   <div class="row">
-    <div class="col-12 u-align--center">
       <h2 class="p-muted-heading u-align-text--center">Used across the public cloud</h2>
     </div>
-
-  <div class="p-fluid-grid--centered">
-    <span class="p-logo-image p-fluid-grid__item--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/a1e6f331-2018-logo-rackspace.svg" alt="Rackspace logo" />
-    </span>
-    <span class="p-logo-image p-fluid-grid__item--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/2274a3e2-2018-logo-OVH.svg" alt="OVH logo" />
-    </span>
-    <span class="p-logo-image p-fluid-grid__item--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/6aec3a9f-2018-logo-vmware.svg" alt="VMware logo" />
-    </span>
-    <span class="p-logo-image p-fluid-grid__item--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/6d027c12-2018-logo-Microsoft-Azure.svg" alt="Microsoft Azure logo" />
-    </span>
-    <span class="p-logo-image p-fluid-grid__item--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/b439df76-2018-logo-AWS.svg" alt="Amazon Web Services logo" />
-    </span>
-    <span class="p-logo-image p-fluid-grid__item--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/bebc29f2-2018-logo-Joyent.svg" alt="Joyent logo" />
-    </span>
-    <span class="p-logo-image p-fluid-grid__item--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/8d9986ed-2018-logo-Fujitsu.svg" alt="Fujitsu logo" />
-    </span>
-    <span class="p-logo-image p-fluid-grid__item--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/5b0a0e80-2018-logo-GCP.svg" alt="Google Cloud Platform logo" />
-    </span>
+  <div class="row">
+  <div class="col-small-2 col-medium-2 col-2">
+    <img src="https://assets.ubuntu.com/v1/a1e6f331-2018-logo-rackspace.svg" alt="Rackspace">
   </div>
-
-    <div class="col-12 u-align--center">
-      <p class="u-align-text--center">
-        <a href="https://partners.ubuntu.com/find-a-partner?programme=certified-public-cloud" class="p-link--external">See our other Ubuntu public cloud partners</a>
-      </p>
-    </div>
+  <div class="col-small-2 col-medium-2 col-2">
+    <img src="https://assets.ubuntu.com/v1/2274a3e2-2018-logo-OVH.svg" alt="OVH">
   </div>
+  <div class="col-small-2 col-medium-2 col-2">
+    <img src="https://assets.ubuntu.com/v1/6aec3a9f-2018-logo-vmware.svg" alt="VMware">
+  </div>
+  <div class="col-small-2 col-medium-2 col-2">
+    <img src="https://assets.ubuntu.com/v1/6d027c12-2018-logo-Microsoft-Azure.svg" alt="Microsoft Azure">
+  </div>
+  <div class="col-small-2 col-medium-2 col-2">
+    <img src="https://assets.ubuntu.com/v1/b439df76-2018-logo-AWS.svg" alt="Amazon Web Services">
+  </div>
+  <div class="col-small-2 col-medium-2 col-2">
+    <img src="https://assets.ubuntu.com/v1/bebc29f2-2018-logo-Joyent.svg" alt="Joyent">
+  </div>
+  <div class="col-small-2 col-medium-2 col-2">
+    <img src="https://assets.ubuntu.com/v1/8d9986ed-2018-logo-Fujitsu.svg" alt="Fujitsu">
+  </div>
+  <div class="col-small-2 col-medium-2 col-2">
+    <img src="https://assets.ubuntu.com/v1/5b0a0e80-2018-logo-GCP.svg" alt="Google Cloud Platform">
+  </div>
+  <div class="row u-align--center">
+      <a href="https://partners.ubuntu.com/find-a-partner?programme=certified-public-cloud" class="p-link--external">See our other Ubuntu public cloud partners</a>
+  </div>
+</div>
 </section>
 
 <section class="p-strip--light">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ layout: default
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="/">
-          <img src="https://assets.ubuntu.com/v1/d9c7e58e-cloud-init-logo-updated.svg" alt="" class="p-navigation__image">
+          <img src="https://assets.ubuntu.com/v1/15971bf5-cloud-init-primary.svg" alt="cloud-init logo" class="p-navigation__image">
         </a>
       </div>
     </div>
@@ -19,28 +19,26 @@ layout: default
 </header>
 
 <section class="p-strip--light">
-  <div class="row">
-    <div class="col-8">
-      <h1>cloud-init</h1>
-      <p class="p-heading--four">The standard for customising cloud instances</p>
-      <a class="p-button--positive" href="https://www.youtube.com/watch?v=-zL3BdbKyGY">
-        <span class="p-link--external">Watch tutorial</span>
-      </a>
+  <div class="row u-vertically-center">
+    <div class="col-7">
+      <h1>The standard for customising cloud instances</h1>
     </div>
+  <div class="col-5">
+    <div class="u-embedded-media">
+  <iframe title="Ubuntu Cloud-Init Technology" class="u-embedded-media__element" src="https://www.youtube.com/watch?v=-zL3BdbKyGY" frameborder="0" allowfullscreen=""></iframe>
+    </div>
+</div>
   </div>
 </section>
 
-<section class="p-strip is-deep is-bordered">
+<section class="p-strip is-bordered">
   <div class="row">
     <div class="col-8">
-      <p>
-        Cloud images are operating system templates and every instance starts out as an identical clone of every other instance. It is the user data that gives every cloud instance its personality and cloud-init is the tool that applies user data to your instances
-        automatically.
-      </p>
+      <p>Cloud images are operating system templates and every instance starts out as an identical clone of every other instance. It is the user data that gives every cloud instance its personality and cloud-init is the tool that applies user data to your instances automatically.</p>
     </div>
   </div>
   <div class="row">
-    <div class="col-9">
+    <div class="col-8">
       <h4>Use cloud-init to configure:</h4>
       <ul class="p-list is-split">
         <li class="p-list__item is-ticked">Setting a default locale</li>
@@ -52,19 +50,14 @@ layout: default
   </div>
 </section>
 
-<section class="p-strip is-deep is-bordered">
+<section class="p-strip">
   <div class="row">
     <div class="col-8">
       <h2>Works with many popular operating systems</h2>
-      <p>
-        While cloud-init started life in Ubuntu, it is now available for most major Linux and FreeBSD operating systems. For cloud image providers, then cloud-init handles many of the differences between cloud vendors automatically &mdash; for example, the official
-        Ubuntu cloud images are identical across all public and private clouds.
-      </p>
+      <p>While cloud-init started life in Ubuntu, it is now available for most major Linux and FreeBSD operating systems. For cloud image providers, then cloud-init handles many of the differences between cloud vendors automatically &mdash; for example, the official Ubuntu cloud images are identical across all public and private clouds.</p>
     </div>
   </div>
   <div class="row">
-    <div class="col-12">
-      <div class="u-equal-height">
         <div class="p-card col-3">
           <header class="p-card__header">
             <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu logo">
@@ -85,13 +78,12 @@ layout: default
         </div>
         <div class="p-card col-3">
           <header class="p-card__header">
-            <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/6947a9e3-redhat.svg" alt="Red Hat logo">
+            <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/5dfb492c-Red_Hat_Logo_2019.svg" alt="Red Hat logo">
           </header>
           <a class="p-link--external" href="https://copr.fedorainfracloud.org/coprs/g/cloud-init/el-stable/">Get packages</a>
         </div>
       </div>
       <div class="row">
-        <div class="u-equal-height">
           <div class="p-card col-3">
             <header class="p-card__header">
               <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/65ab4aca-FREEBSD_Logo_Horiz_Pos_RGB.png" alt="FreeBSD logo">
@@ -106,61 +98,45 @@ layout: default
           </div>
           <div class="p-card col-3">
             <header class="p-card__header">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/ef4f2511-gentoo-type-logo.svg" alt="Gentoo Linux logo">
+              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/edc33d73-gentoo-linux-logo.svg" alt="Gentoo Linux logo">
             </header>
             <a class="p-link--external" href="https://packages.gentoo.org/package/app-emulation/cloud-init">Get packages</a>
           </div>
           <div class="p-card col-3">
             <header class="p-card__header">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/f0b014a6-OpenSUSE_Logo.svg" alt="OpenSUSE logo">
+              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/2e497b2e-opensuse.svg" alt="OpenSUSE logo">
             </header>
             <a class="p-link--external" href="https://build.opensuse.org/package/show/Cloud:Tools/cloud-init">Get packages</a>
           </div>
         </div>
-      </div>
-    </div>
-  </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip--light">
   <div class="row">
-    <div class="col-12">
+    <div class="col-8">
       <h2>Source code</h2>
     </div>
   </div>
   <div class="row">
-    <div class="col-12">
-      <div class="u-equal-height">
         <div class="p-card col-4">
-          <header class="p-card__header">
-            <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/a4cca660-Git-Icon.svg" alt="Git logo">
-          </header>
           <h3 class="p-card__title">Git</h3>
           <p class="p-card__content">Browse and branch from Git.</p>
           <a class="p-link--external" href="https://code.launchpad.net/cloud-init">Git repository</a>
         </div>
         <div class="p-card col-4">
-          <header class="p-card__header">
-            <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/e59251d7-github.svg" alt="GitHub logo">
-          </header>
           <h3 class="p-card__title">GitHub</h3>
           <p class="p-card__content">Browse, branch, fork or clone from GitHub.</p>
           <a class="p-link--external" href="https://github.com/cloud-init/cloud-init">GitHub repository</a>
         </div>
         <div class="p-card col-4">
-          <header class="p-card__header">
-            <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/d656d6b1-picto-download-orange.svg" alt="Download logo">
-          </header>
           <h3 class="p-card__title">Download</h3>
           <p class="p-card__content">Download the officially released archives.</p>
           <a class="p-link--external" href="https://launchpad.net/cloud-init/+download">Download project files</a>
         </div>
       </div>
-    </div>
-  </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section class="p-strip">
   <div class="row">
     <div class="col-12 u-align--center">
       <h2 class="p-muted-heading u-align-text--center">Used across the public cloud</h2>
@@ -199,19 +175,16 @@ layout: default
       </p>
     </div>
   </div>
-</div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip--light">
   <div class="row">
     <div class="col-8">
       <h2>Support</h2>
     </div>
   </div>
   <div class="row">
-    <div class="col-12">
-      <div class="u-equal-height">
-        <div class="col-6 p-card">
+        <div class="col-3 p-card">
           <h4>
             <a class="p-link--external" href="https://cloudinit.readthedocs.org/">Read the docs</a>
           </h4>
@@ -219,49 +192,37 @@ layout: default
             Including datasource and module references, and plenty of examples.
           </p>
         </div>
-        <div class="col-6 p-card">
+        <div class="col-3 p-card">
           <h4>
             <a class="p-link--external" href="https://webchat.freenode.net/">Chat on freenode</a>
           </h4>
           <p>We have an active IRC community on #cloud-init &mdash; get involved!</p>
         </div>
-      </div>
-    </div>
-    <div class="row">
-      <div class="u-equal-height">
-        <div class="col-6 p-card">
+        <div class="col-3 p-card">
           <h4>
             <a class="p-link--external" href="https://stackexchange.com/search?q=cloud-init">Search on Stack Exchange</a>
           </h4>
           <p>Ask questions and search for answers at StackExchange.</p>
         </div>
-        <div class="col-6 p-card">
+        <div class="col-3 p-card">
           <h4>
             <a class="p-link--external" href="https://bugs.launchpad.net/cloud-init/+filebug">Report a bug</a>
           </h4>
           <p>Help us improve the software by flagging bugs and issues you find on Launchpad.</p>
         </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-6">
-      <h2>About</h2>
-      <p>
-        cloud-init is developed and released as free software under both the
-        <a class="p-link--external" href="https://www.gnu.org/licenses/gpl-3.0.en.html">GPLv3 open source license</a>
-        and <a class="p-link--external" href="https://www.apache.org/licenses/LICENSE-2.0">Apache License version 2.0</a>.
-        It was originally designed for the <a class="p-link--external" href="https://www.ubuntu.com/">Ubuntu</a>
-        distribution of Linux in Amazon EC2, but is now supported on many Linux and UNIX distributions in every major cloud.
-      </p>
-    </div>
-  </div>
+        </div>
 </section>
 
 <section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>About</h2>
+      <p>cloud-init is developed and released as free software under both the<a class="p-link--external" href="https://www.gnu.org/licenses/gpl-3.0.en.html">GPLv3 open source license</a>and <a class="p-link--external" href="https://www.apache.org/licenses/LICENSE-2.0">Apache License version 2.0</a>. It was originally designed for the <a class="p-link--external" href="https://www.ubuntu.com/">Ubuntu</a> distribution of Linux in Amazon EC2, but is now supported on many Linux and UNIX distributions in every major cloud.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
   <div class="row">
     <div class="col-12">
       <h2>The team</h2>
@@ -295,4 +256,4 @@ layout: default
   </div>
 </section>
 <script src="/js/global-nav.js"></script>
-<script>canonicalGlobalNav.createNav({maxWidth: '64.875rem'});</script>
+<script>canonicalGlobalNav.createNav({maxWidth: '72rem'});</script>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "global-nav": "2.0.3",
-    "vanilla-framework": "2.0.0-alpha.1"
+    "vanilla-framework": "2.0.1"
   },
   "devDependencies": {
     "autoprefixer": "9.5.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "global-nav": "2.0.3",
-    "vanilla-framework": "2.0.0-alpha"
+    "vanilla-framework": "2.0.0-alpha.1"
   },
   "devDependencies": {
     "autoprefixer": "9.5.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "global-nav": "2.0.3",
-    "vanilla-framework": "1.8.1"
+    "vanilla-framework": "2.0.0-alpha"
   },
   "devDependencies": {
     "autoprefixer": "9.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2994,9 +2994,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@2.0.0-alpha:
-  version "2.0.0-alpha"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.0.0-alpha.tgz#05a0794abc577d66791b2e84bc0207b1e0365b8c"
+vanilla-framework@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.0.1.tgz#028e5cc4a156973f21cbd38ab3758c9532f3c36b"
 
 verbalize@^0.1.2:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2995,9 +2995,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.8.1.tgz#0d7f5885cdbd1355a9f9d42d7596f9a1258b27ea"
+vanilla-framework@2.0.0-alpha:
+  version "2.0.0-alpha"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.0.0-alpha.tgz#05a0794abc577d66791b2e84bc0207b1e0365b8c"
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done
- An updated version of the site to v2.0.1
- Updated components, classes, and utilities based on release notes [here](https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/2.0.1)
- Visual and layout updates 😉 

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8009/](http://0.0.0.0:8009/)
4. Or view demo link below 👍 

## Fixes
- New team members - https://github.com/canonical-web-and-design/cloud-init.io/issues/104

## Screenshot
![cloud init   The standard for customising cloud instances (2)](https://user-images.githubusercontent.com/17748020/58237524-2ba19e80-7d3d-11e9-9a81-969bc69e5ed6.png)

