### PR TITLE
Fix renovate update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Build stage: Install ruby dependencies
 # ===
-FROM ruby:2.7 AS build-site
+FROM ruby:2.5 AS build-site
 WORKDIR /srv
 ADD . .
 RUN bundle install


### PR DESCRIPTION
## Done

- Renovate updated ruby image to `2.7` which doesn't work https://jenkins.canonical.com/webteam/job/cloud-init.io-staging/46/console

- Revert back to `2.5`

## QA

- `export DOCKER_BUILDKIT=1`
- `docker build --tag myimage --build-arg BUILD_ID=myfakeid .`
- `docker run -ti -p 8111:80 myimage`

