### PR TITLE
Eleventy ignores files in the .gitignore

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,0 +1,4 @@
+module.exports = function(eleventyConfig) {
+    eleventyConfig.setUseGitIgnore(false);
+};
+

--- a/.gitignore
+++ b/.gitignore
@@ -58,8 +58,6 @@ env[23]/
 *.css
 
 # Project specific
-/js/global-nav.js
-
 .dotrun.json
 src/js/global-nav.js
 .venv


### PR DESCRIPTION
This is annoying, as we often copy files into /js, but ignore them
from the repo. - e.g. global-nav.js

So we're including a config file that prevents this behaviour.

https://www.11ty.dev/docs/ignores/

QA
--

```
dotrun clean
dotrun
```

Load the site, check global nav loads.