### PR TITLE
allow eleventy to serve ico format files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "yarn run build-css && yarn run build-js && yarn run build-site",
-    "build-site": "eleventy --formats=html,scss,css,js --input=src --output=_site",
+    "build-site": "eleventy --formats=html,scss,css,js,ico --input=src --output=_site",
     "build-css": "node-sass --include-path node_modules src/sass --source-map true --output-style compressed --output src/css && postcss --use autoprefixer --replace 'src/css/**/*.css'",
     "build-js": "cp node_modules/global-nav/dist/index.js src/js/global-nav.js",
     "watch-css": "watch -p 'src/sass/**/*.scss' -c 'yarn run build-css'",
@@ -9,7 +9,7 @@
     "clean": "rm -rf node_modules yarn-error.log src/css *.log _site/",
     "lint-nginx": "gixy nginx.conf",
     "lint-scss": "stylelint src/sass/**/*.scss",
-    "serve": "eleventy --formats=html,scss,css,js --input=src --output=_site --watch --serve --port $PORT",
+    "serve": "eleventy --formats=html,scss,css,js,ico --input=src --output=_site --watch --serve --port $PORT",
     "start": "yarn run build && concurrently --raw 'yarn run watch-css' 'yarn run watch-js' 'yarn run serve'",
     "test": "yarn run lint-nginx && yarn run lint-scss",
     "watch": "watch -p 'static/sass/**/*.scss' -c 'yarn run build'"


### PR DESCRIPTION
## Done

Update the filetypes eleventy can serve to include .ico

## QA

- Checkout this feature branch
- `dotrun` the project
- Visit http://localhost:8009 in your browser
- See that the favicon is present 

## Issue / Card

Fixes https://github.com/canonical-web-and-design/cloud-init.io/issues/140
