### PR TITLE
Fix link to FreeBSD packaegs

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -94,7 +94,7 @@ layout: default
       <header class="p-card__header">
         <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/65ab4aca-FREEBSD_Logo_Horiz_Pos_RGB.png" alt="FreeBSD logo">
       </header>
-      <a class="p-link--external" href="https://pellaeon.github.io/bsd-cloudinit">Get packages</a>
+      <a class="p-link--external" href="https://www.freshports.org/net/cloud-init/">Get packages</a>
     </div>
     <div class="p-card col-3">
       <header class="p-card__header">


### PR DESCRIPTION
## Done

the link was to the bsd-cloudinit fork, which hasn't been updated in ca
5 years. cloud-init itself on the other hand, is being actively
developed and is supported.